### PR TITLE
Fix path handling in LocalFileAccess

### DIFF
--- a/src/main/java/dev/jcputney/elearning/parser/impl/LocalFileAccess.java
+++ b/src/main/java/dev/jcputney/elearning/parser/impl/LocalFileAccess.java
@@ -18,7 +18,6 @@
 package dev.jcputney.elearning.parser.impl;
 
 import dev.jcputney.elearning.parser.api.FileAccess;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -89,10 +88,11 @@ public class LocalFileAccess implements FileAccess {
 
     try (Stream<Path> paths = Files.list(dirPath)) {
       // Use stream API for more secure listing with filtering on regular files only
+      Path basePath = Paths.get(getRootPath());
       return paths
           .filter(Files::isRegularFile) // Only list regular files
+          .map(basePath::relativize)
           .map(Path::toString)
-          .map(path -> path.replace(rootPath + File.separator, ""))
           .toList();
     } catch (IOException e) {
       throw new IOException("Failed to list files in directory: " + directoryPath, e);

--- a/src/test/java/dev/jcputney/elearning/parser/impl/LocalFileAccessTest.java
+++ b/src/test/java/dev/jcputney/elearning/parser/impl/LocalFileAccessTest.java
@@ -345,4 +345,26 @@ class LocalFileAccessTest {
     String path = "subdir//file.txt";
     assertEquals(tempDir.toString() + "/" + path, localFileAccess.fullPath(path));
   }
+
+  @Test
+  void listFiles_withEmptyRootPath_preservesDirectoryStructure() throws IOException {
+    // Use LocalFileAccess without a root path
+    LocalFileAccess access = new LocalFileAccess("");
+
+    // Create a temporary directory and file relative to the current working directory
+    Path tempRoot = Files.createTempDirectory(Paths.get(""), "lfa");
+    Path subDir = Files.createDirectory(tempRoot.resolve("sub"));
+    Path testFile = subDir.resolve("file.txt");
+    Files.write(testFile, "content".getBytes(StandardCharsets.UTF_8));
+
+    try {
+      String relativePath = tempRoot.getFileName() + "/sub";
+      List<String> files = access.listFiles(relativePath);
+      assertTrue(files.contains(relativePath + "/file.txt"));
+    } finally {
+      Files.deleteIfExists(testFile);
+      Files.deleteIfExists(subDir);
+      Files.deleteIfExists(tempRoot);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- avoid removing path separators when LocalFileAccess root path is empty
- add regression test for empty root path listing

## Testing
- `mvn -q -Djacoco.skip=true -Dtest=dev.jcputney.elearning.parser.impl.LocalFileAccessTest test` *(fails: PluginResolutionException)*