### PR TITLE
Increase test coverage for metadata output classes

### DIFF
--- a/src/test/java/dev/jcputney/elearning/parser/output/metadata/AiccMetadataTest.java
+++ b/src/test/java/dev/jcputney/elearning/parser/output/metadata/AiccMetadataTest.java
@@ -1,0 +1,74 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.jcputney.elearning.parser.enums.ModuleType;
+import dev.jcputney.elearning.parser.input.aicc.AssignableUnit;
+import dev.jcputney.elearning.parser.output.metadata.aicc.AiccMetadata;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link AiccMetadata}. */
+class AiccMetadataTest {
+
+  private static class TestAiccManifest extends dev.jcputney.elearning.parser.input.aicc.AiccManifest {
+    private final String title;
+    private final String description;
+    private final String launchUrl;
+    private final String identifier;
+    private final String version;
+    private final Duration duration;
+    private final List<AssignableUnit> units;
+
+    TestAiccManifest(String title, String description, String launchUrl,
+                     String identifier, String version, Duration duration,
+                     List<AssignableUnit> units) {
+      this.title = title;
+      this.description = description;
+      this.launchUrl = launchUrl;
+      this.identifier = identifier;
+      this.version = version;
+      this.duration = duration;
+      this.units = units;
+    }
+
+    @Override public String getTitle() { return title; }
+    @Override public String getDescription() { return description; }
+    @Override public String getLaunchUrl() { return launchUrl; }
+    @Override public String getIdentifier() { return identifier; }
+    @Override public String getVersion() { return version; }
+    @Override public Duration getDuration() { return duration; }
+    @Override public List<AssignableUnit> getAssignableUnits() { return units; }
+  }
+
+  @Test
+  void createAddsAssignableUnitMetadata() {
+    AssignableUnit au1 = AssignableUnit.builder()
+        .systemId("id1")
+        .fileName("file1")
+        .commandLine("cmd")
+        .coreVendor("vendor")
+        .build();
+    AssignableUnit au2 = AssignableUnit.builder()
+        .systemId("id2")
+        .fileName("file2")
+        .commandLine("cmd")
+        .coreVendor("vendor")
+        .build();
+    TestAiccManifest manifest = new TestAiccManifest(
+        "t", "d", "l", "i", "v", Duration.ZERO,
+        List.of(au1, au2));
+
+    AiccMetadata metadata = AiccMetadata.create(manifest, true);
+
+    assertEquals(ModuleType.AICC, metadata.getModuleType());
+    assertTrue(metadata.isXapiEnabled());
+    assertSame(manifest, metadata.getManifest());
+
+    @SuppressWarnings("unchecked")
+    List<String> ids = (List<String>) metadata.getMetadata("assignableUnitIds").orElseThrow();
+    assertEquals(List.of("id1", "id2"), ids);
+    @SuppressWarnings("unchecked")
+    List<String> names = (List<String>) metadata.getMetadata("assignableUnitNames").orElseThrow();
+    assertEquals(List.of("file1", "file2"), names);
+  }
+}

--- a/src/test/java/dev/jcputney/elearning/parser/output/metadata/CompositeMetadataTest.java
+++ b/src/test/java/dev/jcputney/elearning/parser/output/metadata/CompositeMetadataTest.java
@@ -1,0 +1,34 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.jcputney.elearning.parser.output.metadata.CompositeMetadata;
+import dev.jcputney.elearning.parser.output.metadata.SimpleMetadata;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link CompositeMetadata}. */
+class CompositeMetadataTest {
+
+  @Test
+  void addComponentsAndQuery() {
+    SimpleMetadata comp1 = new SimpleMetadata().addMetadata("a", 1);
+    SimpleMetadata comp2 = new SimpleMetadata().addMetadata("b", 2);
+
+    CompositeMetadata composite = new CompositeMetadata();
+    composite.addComponent(comp1).addComponent(comp2);
+
+    assertEquals(1, composite.getMetadata("a", Integer.class).orElseThrow());
+    assertEquals(2, composite.getMetadata("b", Integer.class).orElseThrow());
+    assertTrue(composite.hasMetadata("a"));
+    assertFalse(composite.hasMetadata("c"));
+  }
+
+  @Test
+  void equalityAndHashCode() {
+    SimpleMetadata c = new SimpleMetadata().addMetadata("k", "v");
+    CompositeMetadata one = new CompositeMetadata().addComponent(c);
+    CompositeMetadata two = new CompositeMetadata().addComponent(new SimpleMetadata().addMetadata("k", "v"));
+
+    assertEquals(one, two);
+    assertEquals(one.hashCode(), two.hashCode());
+  }
+}

--- a/src/test/java/dev/jcputney/elearning/parser/output/metadata/Scorm12MetadataTest.java
+++ b/src/test/java/dev/jcputney/elearning/parser/output/metadata/Scorm12MetadataTest.java
@@ -1,0 +1,49 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.jcputney.elearning.parser.enums.ModuleType;
+import dev.jcputney.elearning.parser.output.metadata.scorm12.Scorm12Metadata;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link Scorm12Metadata}. */
+class Scorm12MetadataTest {
+
+  private static class TestScorm12Manifest extends dev.jcputney.elearning.parser.input.scorm12.Scorm12Manifest {
+    private final String title;
+    private final String description;
+    private final String launchUrl;
+    private final String identifier;
+    private final String version;
+    private final Duration duration;
+
+    TestScorm12Manifest(String title, String description, String launchUrl,
+                        String identifier, String version, Duration duration) {
+      this.title = title;
+      this.description = description;
+      this.launchUrl = launchUrl;
+      this.identifier = identifier;
+      this.version = version;
+      this.duration = duration;
+    }
+
+    @Override public String getTitle() { return title; }
+    @Override public String getDescription() { return description; }
+    @Override public String getLaunchUrl() { return launchUrl; }
+    @Override public String getIdentifier() { return identifier; }
+    @Override public String getVersion() { return version; }
+    @Override public Duration getDuration() { return duration; }
+  }
+
+  @Test
+  void createPopulatesBasicMetadata() {
+    TestScorm12Manifest manifest = new TestScorm12Manifest(
+        "t", "d", "l", "i", "v", Duration.ofMinutes(1));
+
+    Scorm12Metadata metadata = Scorm12Metadata.create(manifest, false);
+
+    assertEquals(ModuleType.SCORM_12, metadata.getModuleType());
+    assertFalse(metadata.isXapiEnabled());
+    assertSame(manifest, metadata.getManifest());
+    assertEquals("t", metadata.getMetadata("title", String.class).orElseThrow());
+  }
+}

--- a/src/test/java/dev/jcputney/elearning/parser/output/metadata/Scorm2004MetadataTest.java
+++ b/src/test/java/dev/jcputney/elearning/parser/output/metadata/Scorm2004MetadataTest.java
@@ -1,0 +1,78 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.jcputney.elearning.parser.enums.ModuleType;
+import dev.jcputney.elearning.parser.input.scorm2004.ims.cp.Scorm2004Item;
+import dev.jcputney.elearning.parser.input.scorm2004.ims.cp.Scorm2004Organization;
+import dev.jcputney.elearning.parser.input.scorm2004.ims.cp.Scorm2004Organizations;
+import dev.jcputney.elearning.parser.input.scorm2004.ims.ss.objective.Scorm2004Objective;
+import dev.jcputney.elearning.parser.input.scorm2004.ims.ss.objective.Scorm2004ObjectiveMapping;
+import dev.jcputney.elearning.parser.input.scorm2004.ims.ss.objective.Scorm2004Objectives;
+import dev.jcputney.elearning.parser.input.scorm2004.ims.ss.sequencing.Sequencing;
+import dev.jcputney.elearning.parser.output.metadata.scorm2004.Scorm2004Metadata;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link Scorm2004Metadata}. */
+class Scorm2004MetadataTest {
+
+  private static class TestScorm2004Manifest extends dev.jcputney.elearning.parser.input.scorm2004.Scorm2004Manifest {
+    private final String title;
+    private final String description;
+    private final String launchUrl;
+    private final String identifier;
+    private final String version;
+    private final Duration duration;
+    private final Scorm2004Organizations orgs;
+
+    TestScorm2004Manifest(String title, String description, String launchUrl,
+                          String identifier, String version, Duration duration,
+                          Scorm2004Organizations orgs) {
+      this.title = title;
+      this.description = description;
+      this.launchUrl = launchUrl;
+      this.identifier = identifier;
+      this.version = version;
+      this.duration = duration;
+      this.orgs = orgs;
+    }
+
+    @Override public String getTitle() { return title; }
+    @Override public String getDescription() { return description; }
+    @Override public String getLaunchUrl() { return launchUrl; }
+    @Override public String getIdentifier() { return identifier; }
+    @Override public String getVersion() { return version; }
+    @Override public Duration getDuration() { return duration; }
+    @Override public Scorm2004Organizations getOrganizations() { return orgs; }
+  }
+
+  @Test
+  void createExtractsGlobalObjectiveIds() {
+    Scorm2004ObjectiveMapping mapping = Scorm2004ObjectiveMapping.builder()
+        .targetObjectiveID("obj1").build();
+    Scorm2004Objective objective = Scorm2004Objective.builder()
+        .mapInfo(List.of(mapping)).build();
+    Scorm2004Objectives objectives = Scorm2004Objectives.builder()
+        .objectiveList(List.of(objective)).build();
+    Sequencing sequencing = Sequencing.builder().objectives(objectives).build();
+    Scorm2004Item item = Scorm2004Item.builder().sequencing(sequencing).build();
+    Scorm2004Organization org = Scorm2004Organization.builder()
+        .identifier("o1").items(List.of(item)).build();
+    Scorm2004Organizations orgs = Scorm2004Organizations.builder()
+        .defaultOrganization("o1").organizationList(List.of(org)).build();
+
+    TestScorm2004Manifest manifest = new TestScorm2004Manifest(
+        "t", "d", "l", "i", "v", Duration.ZERO, orgs);
+
+    Scorm2004Metadata metadata = Scorm2004Metadata.create(manifest, true);
+
+    assertEquals(ModuleType.SCORM_2004, metadata.getModuleType());
+    assertTrue(metadata.isXapiEnabled());
+    assertSame(manifest, metadata.getManifest());
+
+    @SuppressWarnings("unchecked")
+    Set<String> ids = (Set<String>) metadata.getMetadata("globalObjectiveIds").orElseThrow();
+    assertEquals(Set.of("obj1"), ids);
+  }
+}

--- a/src/test/java/dev/jcputney/elearning/parser/output/metadata/SimpleMetadataTest.java
+++ b/src/test/java/dev/jcputney/elearning/parser/output/metadata/SimpleMetadataTest.java
@@ -1,0 +1,37 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.jcputney.elearning.parser.output.metadata.SimpleMetadata;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link SimpleMetadata}. */
+class SimpleMetadataTest {
+
+  @Test
+  void addAndRetrieveMetadata() {
+    SimpleMetadata metadata = new SimpleMetadata();
+    metadata.addMetadata("key1", "value1");
+    Map<String, Object> more = new HashMap<>();
+    more.put("key2", 5);
+    metadata.addAllMetadata(more);
+
+    assertTrue(metadata.getMetadata("key1").isPresent());
+    assertEquals("value1", metadata.getMetadata("key1").get());
+    assertEquals(5, metadata.getMetadata("key2", Integer.class).orElseThrow());
+    assertFalse(metadata.getMetadata("missing").isPresent());
+    assertTrue(metadata.hasMetadata("key1"));
+    assertFalse(metadata.hasMetadata("missing"));
+  }
+
+  @Test
+  void equalityAndHashCode() {
+    SimpleMetadata meta1 = new SimpleMetadata();
+    meta1.addMetadata("k", 1);
+    SimpleMetadata meta2 = new SimpleMetadata();
+    meta2.addMetadata("k", 1);
+
+    assertEquals(meta1, meta2);
+    assertEquals(meta1.hashCode(), meta2.hashCode());
+  }
+}


### PR DESCRIPTION
## Summary
- add new SimpleMetadata tests for map operations and equality
- add CompositeMetadata tests for component handling
- add AICC, SCORM 1.2 and SCORM 2004 metadata creation tests

## Testing
- `mvn -q -DskipTests=true test` *(fails: PluginResolutionException)*