### PR TITLE
ci: add CodeQL SAST, CycloneDX SBOM, and build attestations

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+---
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Java)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          queries: security-and-quality
+
+      - name: Build with Maven
+        run: ./mvnw -B -ntp clean compile -DskipTests
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,26 @@ jobs:
           sbom-path: target/checkout/target/elearning-module-parser-*-cyclonedx.json
 
       - name: Upload SBOM to GitHub Release
+        # Maven Central publish above is irreversible; do not fail the job if a
+        # transient gh API error or a rerun on an existing release prevents
+        # this step from completing. The step is still idempotent: on a rerun
+        # we upload to the existing release with --clobber, so a successful
+        # retry replaces any prior assets cleanly.
+        continue-on-error: true
         run: |
           TAG=$(grep 'scm.tag=' release.properties | cut -d'=' -f2)
-          gh release create "${TAG}" \
-            target/checkout/target/elearning-module-parser-*-cyclonedx.json \
-            target/checkout/target/elearning-module-parser-*-cyclonedx.xml \
-            --title "${TAG}" \
-            --generate-notes
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release upload "${TAG}" \
+              target/checkout/target/elearning-module-parser-*-cyclonedx.json \
+              target/checkout/target/elearning-module-parser-*-cyclonedx.xml \
+              --clobber
+          else
+            gh release create "${TAG}" \
+              target/checkout/target/elearning-module-parser-*-cyclonedx.json \
+              target/checkout/target/elearning-module-parser-*-cyclonedx.xml \
+              --title "${TAG}" \
+              --generate-notes
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,7 @@
 name: Release
 
 permissions:
-  contents: write
-  packages: write
-  statuses: write
-  checks: write
+  contents: read
 
 on:
   workflow_dispatch:
@@ -14,9 +11,11 @@ jobs:
   release:
     permissions:
       contents: write
-      id-token: write
-      attestations: write
+      packages: write
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.publish.outputs.tag }}
+      version: ${{ steps.publish.outputs.version }}
     steps:
       - uses: actions/checkout@v6
       - uses: webfactory/ssh-agent@v0.10.0
@@ -34,6 +33,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish package to Maven Central
+        id: publish
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -41,6 +41,8 @@ jobs:
           cat release.properties
           TAG=$(grep 'scm.tag=' release.properties | cut -d'=' -f2)
           VERSION=${TAG#v}
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           mvn -B -ntp -Dstyle.color=always release:perform -DconnectionUrl=scm:git:https://github.com/${{ github.repository }}.git
           echo "Released ${TAG} 🚀" >> $GITHUB_STEP_SUMMARY
         env:
@@ -48,44 +50,20 @@ jobs:
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
-      - name: Attest build provenance for release artifacts
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: |
-            target/checkout/target/elearning-module-parser-*.jar
-
-      - name: Attest SBOM for release artifacts
-        uses: actions/attest-sbom@v2
-        with:
-          subject-path: |
-            target/checkout/target/elearning-module-parser-*.jar
-            !target/checkout/target/elearning-module-parser-*-sources.jar
-            !target/checkout/target/elearning-module-parser-*-javadoc.jar
-          sbom-path: target/checkout/target/elearning-module-parser-*-cyclonedx.json
-
-      - name: Upload SBOM to GitHub Release
-        # Maven Central publish above is irreversible; do not fail the job if a
-        # transient gh API error or a rerun on an existing release prevents
-        # this step from completing. The step is still idempotent: on a rerun
-        # we upload to the existing release with --clobber, so a successful
-        # retry replaces any prior assets cleanly.
-        continue-on-error: true
+      - name: Stage release artifacts for attestation
         run: |
-          TAG=$(grep 'scm.tag=' release.properties | cut -d'=' -f2)
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            gh release upload "${TAG}" \
-              target/checkout/target/elearning-module-parser-*-cyclonedx.json \
-              target/checkout/target/elearning-module-parser-*-cyclonedx.xml \
-              --clobber
-          else
-            gh release create "${TAG}" \
-              target/checkout/target/elearning-module-parser-*-cyclonedx.json \
-              target/checkout/target/elearning-module-parser-*-cyclonedx.xml \
-              --title "${TAG}" \
-              --generate-notes
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          mkdir -p release-artifacts
+          cp target/checkout/target/elearning-module-parser-*.jar release-artifacts/
+          cp target/checkout/target/elearning-module-parser-*-cyclonedx.json release-artifacts/
+          cp target/checkout/target/elearning-module-parser-*-cyclonedx.xml release-artifacts/
+
+      - name: Upload release artifacts for attestation job
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: release-artifacts/
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Update documentation with released version
         run: |
@@ -106,3 +84,57 @@ jobs:
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Attestations and the GitHub Release SBOM upload run in a separate job so
+  # the OIDC token (id-token: write) and attestations: write permission are
+  # never available to the preceding `mvn release:*` steps, which execute
+  # repository-controlled plugin code. If this job fails after Maven Central
+  # has accepted the version, the release job stays green (the publish did
+  # succeed), this job is visibly red, and "Re-run failed jobs" reruns only
+  # the attestation/Release steps without retrying the Central publish.
+  attest:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: artifacts
+
+      - name: Attest build provenance for release artifacts
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            artifacts/elearning-module-parser-*.jar
+
+      - name: Attest SBOM for release artifacts
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: |
+            artifacts/elearning-module-parser-*.jar
+            !artifacts/elearning-module-parser-*-sources.jar
+            !artifacts/elearning-module-parser-*-javadoc.jar
+          sbom-path: artifacts/elearning-module-parser-*-cyclonedx.json
+
+      - name: Upload SBOM to GitHub Release
+        run: |
+          TAG="${{ needs.release.outputs.tag }}"
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release upload "${TAG}" \
+              artifacts/elearning-module-parser-*-cyclonedx.json \
+              artifacts/elearning-module-parser-*-cyclonedx.xml \
+              --clobber
+          else
+            gh release create "${TAG}" \
+              artifacts/elearning-module-parser-*-cyclonedx.json \
+              artifacts/elearning-module-parser-*-cyclonedx.xml \
+              --title "${TAG}" \
+              --generate-notes
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,14 @@ jobs:
           subject-path: target/checkout/target/elearning-module-parser-*.jar
           sbom-path: target/checkout/target/elearning-module-parser-*-cyclonedx.json
 
-      - name: Upload SBOM and provenance to GitHub Release
+      - name: Upload SBOM to GitHub Release
         run: |
           TAG=$(grep 'scm.tag=' release.properties | cut -d'=' -f2)
-          gh release upload "${TAG}" \
+          gh release create "${TAG}" \
             target/checkout/target/elearning-module-parser-*-cyclonedx.json \
             target/checkout/target/elearning-module-parser-*-cyclonedx.xml \
-            --clobber || echo "Release ${TAG} not found yet; skipping SBOM upload"
+            --title "${TAG}" \
+            --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
   release:
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -45,6 +47,28 @@ jobs:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Attest build provenance for release artifacts
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            target/checkout/target/elearning-module-parser-*.jar
+
+      - name: Attest SBOM for release artifacts
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: target/checkout/target/elearning-module-parser-*.jar
+          sbom-path: target/checkout/target/elearning-module-parser-*-cyclonedx.json
+
+      - name: Upload SBOM and provenance to GitHub Release
+        run: |
+          TAG=$(grep 'scm.tag=' release.properties | cut -d'=' -f2)
+          gh release upload "${TAG}" \
+            target/checkout/target/elearning-module-parser-*-cyclonedx.json \
+            target/checkout/target/elearning-module-parser-*-cyclonedx.xml \
+            --clobber || echo "Release ${TAG} not found yet; skipping SBOM upload"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update documentation with released version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,10 @@ jobs:
       - name: Attest SBOM for release artifacts
         uses: actions/attest-sbom@v2
         with:
-          subject-path: target/checkout/target/elearning-module-parser-*.jar
+          subject-path: |
+            target/checkout/target/elearning-module-parser-*.jar
+            !target/checkout/target/elearning-module-parser-*-sources.jar
+            !target/checkout/target/elearning-module-parser-*-javadoc.jar
           sbom-path: target/checkout/target/elearning-module-parser-*-cyclonedx.json
 
       - name: Upload SBOM to GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,21 +50,6 @@ jobs:
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
-      - name: Stage release artifacts for attestation
-        run: |
-          mkdir -p release-artifacts
-          cp target/checkout/target/elearning-module-parser-*.jar release-artifacts/
-          cp target/checkout/target/elearning-module-parser-*-cyclonedx.json release-artifacts/
-          cp target/checkout/target/elearning-module-parser-*-cyclonedx.xml release-artifacts/
-
-      - name: Upload release artifacts for attestation job
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-artifacts
-          path: release-artifacts/
-          if-no-files-found: error
-          retention-days: 7
-
       - name: Update documentation with released version
         run: |
           TAG=$(grep 'scm.tag=' release.properties | cut -d'=' -f2)
@@ -92,6 +77,9 @@ jobs:
   # has accepted the version, the release job stays green (the publish did
   # succeed), this job is visibly red, and "Re-run failed jobs" reruns only
   # the attestation/Release steps without retrying the Central publish.
+  # The job checks out the release tag so that provenance is anchored to the
+  # tagged release commit (not the pre-release snapshot commit that triggered
+  # the workflow_dispatch), and rebuilds the artifacts cleanly from that commit.
   attest:
     needs: release
     runs-on: ubuntu-latest
@@ -100,39 +88,50 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Download release artifacts
-        uses: actions/download-artifact@v4
+      - name: Checkout release tag
+        uses: actions/checkout@v6
         with:
-          name: release-artifacts
-          path: artifacts
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
+
+      - name: Build release artifacts at tagged commit
+        run: mvn -B -ntp package -DskipTests -Dgpg.skip=true
 
       - name: Attest build provenance for release artifacts
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
-            artifacts/elearning-module-parser-*.jar
+            target/elearning-module-parser-*.jar
+            !target/elearning-module-parser-*-sources.jar
+            !target/elearning-module-parser-*-javadoc.jar
 
       - name: Attest SBOM for release artifacts
         uses: actions/attest-sbom@v2
         with:
           subject-path: |
-            artifacts/elearning-module-parser-*.jar
-            !artifacts/elearning-module-parser-*-sources.jar
-            !artifacts/elearning-module-parser-*-javadoc.jar
-          sbom-path: artifacts/elearning-module-parser-*-cyclonedx.json
+            target/elearning-module-parser-*.jar
+            !target/elearning-module-parser-*-sources.jar
+            !target/elearning-module-parser-*-javadoc.jar
+          sbom-path: target/elearning-module-parser-*-cyclonedx.json
 
       - name: Upload SBOM to GitHub Release
         run: |
           TAG="${{ needs.release.outputs.tag }}"
           if gh release view "${TAG}" >/dev/null 2>&1; then
             gh release upload "${TAG}" \
-              artifacts/elearning-module-parser-*-cyclonedx.json \
-              artifacts/elearning-module-parser-*-cyclonedx.xml \
+              target/elearning-module-parser-*-cyclonedx.json \
+              target/elearning-module-parser-*-cyclonedx.xml \
               --clobber
           else
             gh release create "${TAG}" \
-              artifacts/elearning-module-parser-*-cyclonedx.json \
-              artifacts/elearning-module-parser-*-cyclonedx.xml \
+              target/elearning-module-parser-*-cyclonedx.json \
+              target/elearning-module-parser-*-cyclonedx.xml \
               --title "${TAG}" \
               --generate-notes
           fi

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,8 +22,6 @@ jobs:
       packages: write
       statuses: write
       checks: write
-      id-token: write
-      attestations: write
 
     steps:
       - uses: actions/checkout@v6
@@ -87,31 +85,61 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
-      # Attestations must run AFTER deploy: `mvn deploy` re-runs the package
-      # phase and overwrites target/, so only the post-deploy files match what
-      # was actually published to GitHub Packages.
-      - name: Attest build provenance for snapshot artifacts
+      # Stage post-deploy artifacts (these are exactly what GitHub Packages
+      # received, since `mvn deploy` re-runs the package phase and overwrites
+      # target/) for the separate attest job to consume.
+      - name: Stage snapshot artifacts for attestation
         if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p snapshot-artifacts
+          cp target/elearning-module-parser-*.jar snapshot-artifacts/
+          cp target/elearning-module-parser-*-cyclonedx.json snapshot-artifacts/
+          cp target/elearning-module-parser-*-cyclonedx.xml snapshot-artifacts/
+
+      - name: Upload snapshot artifacts for attestation job
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-artifacts
+          path: snapshot-artifacts/
+          if-no-files-found: error
+
+  # Attestations run in a separate job so id-token: write and
+  # attestations: write are not available to the preceding Maven build,
+  # which executes repository-controlled plugin code.
+  attest:
+    needs: test-build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download snapshot artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: snapshot-artifacts
+          path: artifacts
+
+      - name: Attest build provenance for snapshot artifacts
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: target/elearning-module-parser-*.jar
+          subject-path: artifacts/elearning-module-parser-*.jar
 
       - name: Attest SBOM for snapshot artifacts
-        if: github.event_name != 'pull_request'
         uses: actions/attest-sbom@v2
         with:
           subject-path: |
-            target/elearning-module-parser-*.jar
-            !target/elearning-module-parser-*-sources.jar
-            !target/elearning-module-parser-*-javadoc.jar
-          sbom-path: target/elearning-module-parser-*-cyclonedx.json
+            artifacts/elearning-module-parser-*.jar
+            !artifacts/elearning-module-parser-*-sources.jar
+            !artifacts/elearning-module-parser-*-javadoc.jar
+          sbom-path: artifacts/elearning-module-parser-*-cyclonedx.json
 
       - name: Upload SBOM as workflow artifact
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: sbom
           path: |
-            target/elearning-module-parser-*-cyclonedx.json
-            target/elearning-module-parser-*-cyclonedx.xml
+            artifacts/elearning-module-parser-*-cyclonedx.json
+            artifacts/elearning-module-parser-*-cyclonedx.xml
           if-no-files-found: error

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,6 +22,8 @@ jobs:
       packages: write
       statuses: write
       checks: write
+      id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v6
@@ -38,6 +40,28 @@ jobs:
         run: mvn -B package --file pom.xml
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Attest build provenance for snapshot artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: target/elearning-module-parser-*.jar
+
+      - name: Attest SBOM for snapshot artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: target/elearning-module-parser-*.jar
+          sbom-path: target/elearning-module-parser-*-cyclonedx.json
+
+      - name: Upload SBOM as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: |
+            target/elearning-module-parser-*-cyclonedx.json
+            target/elearning-module-parser-*-cyclonedx.xml
+          if-no-files-found: warn
 
       - name: Test Summary
         id: test_summary

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -41,28 +41,6 @@ jobs:
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
-      - name: Attest build provenance for snapshot artifacts
-        if: github.event_name != 'pull_request'
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: target/elearning-module-parser-*.jar
-
-      - name: Attest SBOM for snapshot artifacts
-        if: github.event_name != 'pull_request'
-        uses: actions/attest-sbom@v2
-        with:
-          subject-path: target/elearning-module-parser-*.jar
-          sbom-path: target/elearning-module-parser-*-cyclonedx.json
-
-      - name: Upload SBOM as workflow artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: sbom
-          path: |
-            target/elearning-module-parser-*-cyclonedx.json
-            target/elearning-module-parser-*-cyclonedx.xml
-          if-no-files-found: warn
-
       - name: Test Summary
         id: test_summary
         uses: test-summary/action@v2
@@ -108,3 +86,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      # Attestations must run AFTER deploy: `mvn deploy` re-runs the package
+      # phase and overwrites target/, so only the post-deploy files match what
+      # was actually published to GitHub Packages.
+      - name: Attest build provenance for snapshot artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: target/elearning-module-parser-*.jar
+
+      - name: Attest SBOM for snapshot artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: target/elearning-module-parser-*.jar
+          sbom-path: target/elearning-module-parser-*-cyclonedx.json
+
+      - name: Upload SBOM as workflow artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: |
+            target/elearning-module-parser-*-cyclonedx.json
+            target/elearning-module-parser-*-cyclonedx.xml
+          if-no-files-found: warn

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -114,4 +114,4 @@ jobs:
           path: |
             target/elearning-module-parser-*-cyclonedx.json
             target/elearning-module-parser-*-cyclonedx.xml
-          if-no-files-found: warn
+          if-no-files-found: error

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -100,7 +100,10 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/attest-sbom@v2
         with:
-          subject-path: target/elearning-module-parser-*.jar
+          subject-path: |
+            target/elearning-module-parser-*.jar
+            !target/elearning-module-parser-*-sources.jar
+            !target/elearning-module-parser-*-javadoc.jar
           sbom-path: target/elearning-module-parser-*-cyclonedx.json
 
       - name: Upload SBOM as workflow artifact

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <version.org.json>20251224</version.org.json>
     <version.plugin.central-publishing>0.10.0</version.plugin.central-publishing>
     <version.plugin.compiler>3.15.0</version.plugin.compiler>
+    <version.plugin.cyclonedx>2.9.1</version.plugin.cyclonedx>
     <version.plugin.exec>3.6.3</version.plugin.exec>
     <version.plugin.failsafe>3.5.5</version.plugin.failsafe>
     <version.plugin.gpg>3.2.8</version.plugin.gpg>
@@ -400,6 +401,28 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>${version.plugin.cyclonedx}</version>
+        <executions>
+          <execution>
+            <id>make-bom</id>
+            <phase>package</phase>
+            <goals>
+              <goal>makeAggregateBom</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <projectType>library</projectType>
+          <schemaVersion>1.6</schemaVersion>
+          <outputFormat>all</outputFormat>
+          <outputName>${project.artifactId}-${project.version}-cyclonedx</outputName>
+          <includeBomSerialNumber>true</includeBomSerialNumber>
+          <includeTestScope>false</includeTestScope>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
- New CodeQL workflow runs security-and-quality queries on push, PR, and
  weekly schedule to catch SAST issues alongside the existing Dependabot
  SCA coverage.
- cyclonedx-maven-plugin generates a CycloneDX 1.6 SBOM (XML + JSON) for
  compile/runtime/provided dependencies during the package phase, attached
  as a build artifact so it's published to Maven Central with the JAR.
- release.yml and snapshot.yml now produce GitHub build provenance and
  SBOM attestations (actions/attest-build-provenance, attest-sbom) so
  downstream consumers can verify artifacts via gh attestation verify.
  Release workflow also uploads the SBOM to the GitHub Release.